### PR TITLE
Iv 1209 tss fix rewrap

### DIFF
--- a/rll/collectd.sh
+++ b/rll/collectd.sh
@@ -339,7 +339,6 @@ if [[ "$(collectd -h)" =~ "collectd 4" ]]; then
 fi
 configure_collectd_plugin write_http \
   "<URL \"http://127.0.0.1:$RS_RLL_PORT/rll/tss/collectdv$collectd_ver\">" \
-  "  BufferSize 16384" \
   "</URL>"
 
 configure_collectd_plugin load


### PR DESCRIPTION
Accomplish a few things:
Docs mention you can unwrap/rewrap to upgrade RightLink for enabled servers -- this would support that case. 
Workaround for some image issues or using snapshotted images. 
