### PR TITLE
IV-2478 Fix for collectd.sh on CentOS 6 when SELinux enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changelog for the RightLink10 Base ServerTemplate
 =================================================
 
+10.1.5
+------
+- Fix collectd.sh script failure on CentOS 6 when SELinux is enabled.
+
 10.1.4
 ------
 - Added rll-compat::rightscale-mirrors for configuring RightScale-hosted OS repository mirrors

--- a/rll/collectd.sh
+++ b/rll/collectd.sh
@@ -199,7 +199,9 @@ fi
 # high port for localhost (127.0.0.1). Without this permission relaxed, we'll get
 # permission denied connecting to that local ip
 if sestatus 2>/dev/null | grep "SELinux status" | grep enabled; then
-  sudo setsebool -P collectd_tcp_network_connect 1
+  if getsebool -a | grep collectd_tcp_network_connect >/dev/null 2>&1; then
+    sudo setsebool -P collectd_tcp_network_connect 1
+  fi
 fi
 
 sudo mkdir --mode=0755 --parents $collectd_conf_plugins_dir $collectd_base_dir $collectd_plugin_dir

--- a/rll/collectd.sh
+++ b/rll/collectd.sh
@@ -199,7 +199,9 @@ fi
 # high port for localhost (127.0.0.1). Without this permission relaxed, we'll get
 # permission denied connecting to that local ip
 if sestatus 2>/dev/null | grep "SELinux status" | grep enabled; then
-  if getsebool -a | grep collectd_tcp_network_connect >/dev/null 2>&1; then
+  # Existence check - on CentOS 6 this variable doesn't exist and isn't needed
+  if getsebool collectd_tcp_network_connect >/dev/null 2>&1; then
+    echo "Setting SELinux variable collectd_tcp_network_connect to on"
     sudo setsebool -P collectd_tcp_network_connect 1
   fi
 fi

--- a/rll/metadata.rb
+++ b/rll/metadata.rb
@@ -2,7 +2,7 @@ name        "rll"
 maintainer  "RightScale, Inc."
 license     "see LICENSE file in repository root"
 description "Base scripts for RightLink10 on Linux (RLL) to initialize basic functionality"
-version     '10.1.4'
+version     '10.1.5'
 
 recipe      "rll::wait-for-eip", "Wait for external IP address to be assigned (EC2 issue)"
 recipe      "rll::security_updates", "Installs security updates"


### PR DESCRIPTION
For CentOS 7, a SELinux variable to enable collectd to create TCP
connections is needed . On CentOS 6, we try to set this variable and
fail. This variable doesn't exist and isn't needed there.
