### PR TITLE
Remove redundant tagging for Windows monitoring script.

### DIFF
--- a/rlw/enable_monitoring.ps1
+++ b/rlw/enable_monitoring.ps1
@@ -7,6 +7,3 @@
 
 # Enable built-in monitoring
 rsc rl10 put_control /rll/tss/control enable_monitoring=true
-
-# Add the RightScale monitoring active tag
-rsc --rl10 cm15 multi_add /api/tags/multi_add resource_hrefs[]=$env:RS_SELF_HREF tags[]=rs_monitoring:state=auth


### PR DESCRIPTION
RightLink 10 now handles the tagging for monitoring already so there is no need to do it in the script.
