### PR TITLE
Iv 2436 updates for rightscript sync upload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/EfrainOlivares/rightscript_sync.git
-  revision: 6fc5bf3cf5db726d94252f583ba70f85f9ac03e1
+  revision: 092954d299c8380df8c414e7170b066a278412fb
   branch: master
   specs:
     rightscript_sync (0.0.0)
-      right_api_client (~> 1.5.26)
+      right_api_client (~> 1.6.0)
       terminal-table
       thor
 
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -22,7 +22,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    right_api_client (1.5.28)
+    right_api_client (1.6.1)
       json (~> 1.0)
       mime-types (~> 1.0)
       rest-client (~> 1.6)

--- a/rll-examples/rightscale-mirrors.sh
+++ b/rll-examples/rightscale-mirrors.sh
@@ -40,7 +40,7 @@
 #     Category: RightScale
 #     Description: RightScale provides mirrors of some OS distributions. This would be the hostname of one of
 #       those mirrors (typically env:RS_ISLAND)
-#     Default: "text:"
+#     Default: env:RS_ISLAND
 #     Required: true
 #     Advanced: true
 # ...

--- a/rll-examples/rightscale-mirrors.sh
+++ b/rll-examples/rightscale-mirrors.sh
@@ -2,16 +2,20 @@
 
 # ---
 # RightScript Name: RL10 Linux RightScale Mirrors
-# Description: RightScale provides mirrors of some OS distributions. Snapshots of these mirrors
+# Description: |
+#   RightScale provides mirrors of some OS distributions. Snapshots of these mirrors
 #   are taken daily so that any the mirrors can be "frozen" to any given day. These
 #   mirrors also usually come from a fixed IP range for firewall friendliness. The
 #   mirrors may be browsed at mirror.rightscale.com. For further information, see
 #   https://support.rightscale.com/12-Guides/RightScale_101/System_Architecture/Rightscale_OS_Software_Mirrors/.
-# The following are available:
-#   Ubuntu main, universe, security-updates mirrors (/ubuntu_daily)
-#   CentOS Base, addons, extras, update mirrors (/centos)
-#   Fedora EPEL (/epel)
-#   Rubygems (/rubygems)
+#
+#   ## The following are available:
+#
+#   * Ubuntu main, universe, security-updates mirrors (/ubuntu_daily)
+#   * CentOS Base, addons, extras, update mirrors (/centos)
+#   * Fedora EPEL (/epel)
+#   * Rubygems (/rubygems)
+#
 # Inputs:
 #   FREEZE_DATE:
 #     Input Type: single
@@ -19,7 +23,7 @@
 #     Description: Day from which to set RightScale-hosted OS repository mirror. Can be an empty string to
 #       disable this feature, 'latest' to always pull today's mirrors, or a day in format YYYY-MM-DD to pull
 #       from a particular day
-#     Default: text:
+#     Default: "text:"
 #     Required: true
 #     Advanced: true
 #   RUBYGEMS_FREEZE_DATE:
@@ -28,7 +32,7 @@
 #     Description: Day from which to set RightScale-hosted Rubygems mirror. Can be an empty string to disable
 #       this feature, 'latest' to always pull today's mirrors, or a day in format YYYY-MM-DD to pull from a
 #       particular day
-#     Default: text:
+#     Default: "text:"
 #     Required: true
 #     Advanced: true
 #   MIRROR_HOST:
@@ -36,7 +40,7 @@
 #     Category: RightScale
 #     Description: RightScale provides mirrors of some OS distributions. This would be the hostname of one of
 #       those mirrors (typically env:RS_ISLAND)
-#     Default: text:
+#     Default: "text:"
 #     Required: true
 #     Advanced: true
 # ...


### PR DESCRIPTION
In using rightscript_sync, got several errors on the yaml format of the metadata header of rll-examples/rightscale-mirrors.sh.  Also did a build update.

Since no active code was changed, the only test I ran was running:

```
bundle exec rightscript_sync upload rll-examples/rightscale-mirrors.sh
```
