### PR TITLE
IV-3930 Do self check before we replace any executables.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 Changelog for the RightLink10 Base ServerTemplate
 =================================================
 
-10.2.2
+10.3.0
 ------
 - Update scripts with support for CoreOS
 - Replaced rll/collectd.sh with rll/enable-monitoring.sh (RL10 Linux Enable Monitoring)
+- Fix upgrade script audit entry sometimes getting cut short
 
 10.2.1
 ------

--- a/rll/upgrade.sh
+++ b/rll/upgrade.sh
@@ -144,13 +144,13 @@ if [[ "$new" == "$desired" ]]; then
 
   # We pre-run the self-check now so we can fail fast.
   . <(sudo sed '/^export/!s/^/export /' /var/lib/rightscale-identity)
-  self_check_output=$(${bin_dir}/rightlink-new --selfcheck >/dev/null 2>&1)
-  if [ "$?" -eq 0 ]; then
+  self_check_output=$(${bin_dir}/rightlink-new --selfcheck 2>&1)
+  if [[ "$self_check_output" =~ "Self-check succeeded" ]]; then
     echo "new version passed connectivity check"
   else
-      echo "initial self-check failed:"
-      echo "$self_check_output"
-      exit 1
+    echo "initial self-check failed:"
+    echo "$self_check_output"
+    exit 1
   fi
 
   echo "restarting RightLink to pick up new version"

--- a/rll/upgrade.sh
+++ b/rll/upgrade.sh
@@ -28,7 +28,7 @@ upgrade_rightlink() {
   # Use 'logger' here instead of 'echo' since stdout from this is not sent to
   # audit entries as RightLink is down for a short time during the upgrade process.
 
-  res=$(${bin_dir}/rsc --timeout=60 rl10 upgrade /rll/upgrade exec=${bin_dir}/rightlink-new 2>/dev/null || true)
+  res=$(${bin_dir}/rsc rl10 upgrade /rll/upgrade exec=${bin_dir}/rightlink-new 2>/dev/null || true)
   if [[ "$res" =~ successful ]]; then
     # Delete the old version if it exists from the last upgrade.
     sudo rm -rf ${bin_dir}/rightlink-old
@@ -145,8 +145,10 @@ if [[ "$new" == "$desired" ]]; then
   # We pre-run the self-check now so we can fail fast.
   . <(sudo sed '/^export/!s/^/export /' /var/lib/rightscale-identity)
   self_check_output=$(${bin_dir}/rightlink-new --selfcheck >/dev/null 2>&1)
-  if [ "$?" -ne 0 ]; then
-      echo "Initial self-check failed:"
+  if [ "$?" -eq 0 ]; then
+    echo "new version passed connectivity check"
+  else
+      echo "initial self-check failed:"
       echo "$self_check_output"
       exit 1
   fi


### PR DESCRIPTION
Should make the upgrade script more user friendly by failing immediately
if the new binary is bad.
