### PR TITLE
IV-3930 Bump time to wait for upgrade from 10 to 25 seconds

### DIFF
--- a/rlw/upgrade.ps1
+++ b/rlw/upgrade.ps1
@@ -51,7 +51,7 @@ $upgradeFunction = {
         break
       } else {
         Write-Output 'Waiting for new version to become active.'
-        Sleep 2
+        Sleep 5
       }
     }
     if ($newInstalledVersion -ne $desiredVersion) {


### PR DESCRIPTION
Makes linux and windows the same and allows a bit of retrying
of authentication
