### PR TITLE
Updated Windows IIS/SQL monitor install scripts

### DIFF
--- a/rlw-examples/iis-monitoring.ps1
+++ b/rlw-examples/iis-monitoring.ps1
@@ -12,4 +12,4 @@ if (!$attachDir) {
   $attachDir = [System.IO.Path]::GetFullPath(".\attachments")
 }
 
-rsc rl10 create /rll/tss/exec/mssql_monitor executable=[io.path]::combine($attachDir, "iis-monitor.ps1")
+rsc rl10 create /rll/tss/exec/mssql_monitor executable=$([io.path]::combine($attachDir, "iis-monitor.ps1"))

--- a/rlw-examples/mssql-monitoring.ps1
+++ b/rlw-examples/mssql-monitoring.ps1
@@ -1,6 +1,6 @@
 # ---
 # RightScript Name: DB SQLS Install monitors
-# Description: Installs Microsoft SQL Server specific monitoring. 
+# Description: Installs Microsoft SQL Server specific monitoring.
 # Inputs: {}
 # Attachments:
 #   - iis-monitor.ps1
@@ -12,4 +12,4 @@ if (!$attachDir) {
   $attachDir = [System.IO.Path]::GetFullPath(".\attachments")
 }
 
-rsc rl10 create /rll/tss/exec/mssql_monitor executable=[io.path]::combine($attachDir, "mssql-monitor.ps1")
+rsc rl10 create /rll/tss/exec/mssql_monitor executable=$([io.path]::combine($attachDir, "mssql-monitor.ps1"))


### PR DESCRIPTION
Updated to resolve this error message:
STDERR> [ERROR] Arguments must be of the form NAME=VALUE, value
provided was
'C:\Users\RIGHTL~1\AppData\Local\Temp\rightlink\scripts\rll-040280476'
