### PR TITLE
IV-4843 Make Enable Managed Login output cleaner

### DIFF
--- a/rll/enable-managed-login.sh
+++ b/rll/enable-managed-login.sh
@@ -82,7 +82,7 @@ else
   bin_dir="/usr/local/bin"
 fi
 
-if ! $rsc rl10 actions | grep --ignore-case --quiet /rll/login/control >/dev/null 2>&1; then
+if ! $rsc rl10 actions | grep --ignore-case /rll/login/control >/dev/null 2>&1; then
   echo "This script must be run on a RightLink 10.5 or newer instance"
   exit 1
 fi

--- a/rll/enable-managed-login.sh
+++ b/rll/enable-managed-login.sh
@@ -82,7 +82,7 @@ else
   bin_dir="/usr/local/bin"
 fi
 
-if ! $rsc rl10 actions | grep --ignore-case /rll/login/control >/dev/null 2>&1; then
+if ! $rsc rl10 actions 2>/dev/null | grep --ignore-case --quiet /rll/login/control; then
   echo "This script must be run on a RightLink 10.5 or newer instance"
   exit 1
 fi


### PR DESCRIPTION
Tested on RL 10.4.0 and RL 10.5.0 instance. 
The `STDERR> [ERROR] write /dev/stdout: broken pipe` is removed form the output 
