### PR TITLE
IV-4957 Only install subscription-manager if it is not already instal…

### DIFF
--- a/rll/redhat-subscription-register.sh
+++ b/rll/redhat-subscription-register.sh
@@ -84,7 +84,9 @@ if ([[ -z $REDHAT_ACCOUNT_USERNAME ]] || [[ -z $REDHAT_ACCOUNT_PASSWORD ]]); the
 fi
 
 # Install subscription-manager
-retry_command sudo yum --assumeyes install subscription-manager
+if ! type -P subscription-manager > /dev/null; then
+  retry_command sudo yum --assumeyes install subscription-manager
+fi
 
 # Register server if not already
 subscription_status_retries=5


### PR DESCRIPTION
…led because some RHEL images do not have any repos configured before registration
