### PR TITLE
IV-4904 Initial commits of disable monitoring script

### DIFF
--- a/rll-examples/disable-monitoring.sh
+++ b/rll-examples/disable-monitoring.sh
@@ -1,0 +1,116 @@
+#! /bin/bash -e
+
+# ---
+# RightScript Name: RightScale Linux Disable Monitoring
+# Description: |
+#   This downgrades an instance from Level 3 support (full capabilities) to
+#   Level 2 support by disabling monitoring. It can be run against any RightLink 5, 6
+#   or 10 Server. It must be run after every reboot as the scripts in the "Boot
+#   Scripts" will re-enable monitoring every boot and and can't be disabled.
+# Inputs: {}
+# ...
+#
+
+# How this downgrade is accomplished differs by RightLink version. We try to be
+# as minimally instrusive as possible, merely removing sending of any collectd
+# stats to RightScale rather than disable collectd outright.
+#
+# The exact strategy to use differs by RightLink version/os.
+
+sudo=
+retry_flags=
+# Ensure rsc is in the path
+export PATH="/usr/local/bin:/opt/bin:$PATH"
+which rsc >/dev/null && (rsc --help | grep retry >/dev/null) && retry_flags="--retry=5 --timeout=10"
+# Ensure we sudo for RL10, which runs as the rightlink user. Don't sudo for RL6, which
+# already runs as root and may fail due to sudoers configuration issues in some cases
+which rightlink >/dev/null && sudo="sudo"
+
+# RL 10 supports built-in monitoring. Disable it if we detect it as on
+if which rightlink >/dev/null 2>&1; then
+  # Built-in monitoring didn't ship until 10.2.1, which also shipped with rsc.
+  if which rsc >/dev/null 2>&1; then
+    output=$(rsc rl10 show /rll/tss/control/enable_monitoring 2>/dev/null)
+    if [[ "$output" =~ enable_monitoring ]] && [[ ! "$output" =~ "none" ]] && [[ ! "$output" =~ "false" ]]; then
+      echo "RightLink 10 built-in monitoring is enabled. Disabling it."
+      rsc rl10 $retry_flags update /rll/tss/control enable_monitoring=false
+    else
+      echo "RightLink 10 built-in monitoring is disabled."
+    fi
+  fi
+fi
+
+# RL 6 relied on collectd as a standalone service, which sends data directly to
+# RightScale "sketchy" servers using the network plugin (UDP). Only the collectd
+# v4 format is understood by UDP-based infrastructure. RL10 uses the native OS
+# collectd, which can be collectd 4 or 5. In either case the data is sent over
+# http to the RightLink client which adds an auth header and sends it onto the
+# RightScale TSS servers. 
+# Ubuntu location: /etc/collectd/plugins, RHEL/CentOS location: /etc/collectd.d
+plugins_dir=/etc/collectd.d
+if [[ -d /etc/collectd/plugins ]]; then
+  plugins_dir=/etc/collectd/plugins
+fi
+collectd_conf=/etc/collectd.conf
+if [[ -e /etc/collectd/collectd.conf ]]; then 
+  collectd_conf=/etc/collectd/collectd.conf
+fi
+if [[ -e $collectd_conf ]]; then
+  echo "Collectd based monitoring detected."
+  locations=($plugins_dir/network.conf $plugins_dir/write_http.conf)
+  for filename in ${locations[*]}; do
+    if $sudo test -f "$filename"; then
+      if $sudo grep -E 'rightscale|rll/tss' "$filename" 2>/dev/null; then
+        echo "RightScale collectd-based monitoring is enabled. Disabling collectd configuration $filename."
+        backup_time=$(date -u +%Y%m%d%H%M%S)
+        $sudo mv "${filename}" "${filename}.${backup_time}"
+        restart_collectd=1
+      fi
+    fi
+  done
+
+  # From https://collectd.org/wiki/index.php/Table_of_Plugins, all known "write"
+  # plugins. If there are no write plugins enabled, collectd will spew errors
+  # continually and is non-functional. Disable it in that case.
+  write_plugins_regex="Plugin .*(amqp|carbon_writer|csv|network|rrdcached|rrdtool|unixsock|write_.*)"
+  if $sudo grep -E "$write_plugins_regex" $(ls $plugins_dir/*.conf $collectd_conf); then
+    echo "Found alternative collectd write plugin. Collectd will not be disabled."
+  else
+    echo "Found no collectd writer plugin other than the RightScale one."
+    echo "Disabling collectd service as it does not appear to be setup for anything other than RightScale monitoring."
+    disable_collectd=1
+  fi
+
+  if [[ "$disable_collectd" == "1" ]]; then
+    if which chkconfig; then
+      $sudo chkconfig collectd off
+    elif which update-rc.d; then
+      $sudo update-rc.d collectd disable
+    fi
+    echo "Collectd disabled. Stopping collectd service"
+    if $sudo service collectd status; then
+      $sudo service collectd stop
+    fi
+  elif [[ "$restart_collectd" == "1" ]]; then
+    echo "Collectd configuration changed. Restarting collectd service."
+    if $sudo service collectd status; then
+      $sudo service collectd restart
+    fi
+  else
+    echo "No changes to collectd configuration were needed."
+  fi
+fi
+
+if which rightlink >/dev/null 2>&1; then
+  rsc $retry_flags --rl10 cm15 multi_delete /api/tags/multi_delete \
+    "resource_hrefs[]=$RS_SELF_HREF" \
+    "tags[]=rs_monitoring:state=auth" \
+    "tags[]=rs_monitoring:state=active" \
+    "tags[]=rs_monitoring:util=v2"
+else
+  tags=$(rs_tag --list | grep rs_monitoring | sed 's/^[ ]*"//' | sed 's/".*//')
+  for tag in $tags; do
+    echo "Removing tag $tag"
+    rs_tag --remove "$tag"
+  done
+fi

--- a/rlw-examples/disable-monitoring.ps1
+++ b/rlw-examples/disable-monitoring.ps1
@@ -1,0 +1,60 @@
+# ---
+# RightScript Name: RightScale Windows Disable Monitoring
+# Description: |
+#   This downgrades an instance from Level 3 support (full capabilities) to
+#   Level 2 support by disabling monitoring. It can be run against any RightLink 5, 6
+#   or 10 Server. It must be run after every reboot as the scripts in the "Boot
+#   Scripts" will re-enable monitoring every boot and and can't be disabled.
+# Inputs: {}
+# ...
+#
+
+# RightLink 10 has built-in monitoring, which we simply disable. RightLink 5/6
+# has a side-car ruby service which gathered monitoring data which we proceed
+# to disable.
+
+$rl6ServiceDir = "${env:ProgramFiles(x86)}\RightScale\RightLinkService"
+$scriptsDir = "$rl6ServiceDir\scripts"
+
+if (Test-Path "C:\Program Files\RightScale\RightLink\rsc.exe") {
+  $rsc="C:\Program Files\RightScale\RightLink\rsc.exe"
+  $output=& $rsc rl10 show /rll/tss/control/enable_monitoring
+  if ($output -Match "enable_monitoring" -and $output -Match "false") {
+    & $rsc rl10 $retry_flags update /rll/tss/control enable_monitoring=false
+    Write-Output "RightLink 10 built-in monitoring is enabled. Disabling it."
+  } else {
+    Write-Output "RightLink 10 built-in monitoring is disabled."
+  }
+  & $rsc --rl10 cm15 multi_delete /api/tags/multi_delete "resource_hrefs[]=$env:RS_SELF_HREF" "tags[]=rs_monitoring:state=auth" "tags[]=rs_monitoring:state=active" "tags[]=rs_monitoring:util=v2"
+} elseif (Test-Path $rl6ServiceDir) {
+  Write-Output "Checking for RightLink 5/6 based monitoring"
+  if (!(Test-Path "$scriptsDir")) {
+    Write-Output "Cannot find $scriptsDir, monitoring is disabled."
+    exit 0
+  }
+  $files = @(Get-ChildItem $scriptsDir)
+  if ($files.Length -gt 0) {
+    Write-Output "RightLink based 5/6 monitoring enabled, disabling"
+    foreach ($file in $files) {
+      Remove-Item $file.FullName -Force -Recurse
+    }
+  } else {
+    Write-Output "RightScale monitoring is disabled."
+  }
+  $rubyProcs = Get-WmiObject win32_process -Filter "name='ruby.exe'"
+  ForEach($proc in $rubyProcs) {
+    if ($proc.CommandLine -Match "monitoring") {
+      Write-Output "Killing monitoring process PID $($proc.ProcessId)"
+      taskkill.exe /PID $proc.ProcessId /F
+    }
+  }
+  $tags = rs_tag --list
+  if ($tags -Match "rs_monitoring") {
+    Write-Output "Removing rs_monitoring:state=active tag"
+    rs_tag --remove "rs_monitoring:state=active"
+  }
+} else {
+  Write-Output "Neither RightLink 10 or RightLink 5/6 style monitoring detected!"
+  exit 1
+}
+


### PR DESCRIPTION
This downgrades an instance from Level 3 support (full capabilities) to Level 2 support by disabling monitoring. It can be run against any RightLink 5, 6 or 10 Server and must be run every boot.
