### PR TITLE
IV-5002 Use .x naming for CentOS/RHEL MCIs

### DIFF
--- a/rll/base.yml
+++ b/rll/base.yml
@@ -73,47 +73,19 @@ RightScripts:
   - redhat-subscription-unregister.sh
 MultiCloudImages:
 - Name: Ubuntu_14.04_x64
-  Revision: 54
-  Publisher: RightScale
 - Name: Ubuntu_14.04_x64_KVM
-  Revision: 28
-  Publisher: RightScale
 - Name: Ubuntu_12.04_x64
-  Revision: 53
-  Publisher: RightScale
 - Name: Ubuntu_12.04_x64_KVM
-  Revision: 28
-  Publisher: RightScale
-- Name: CentOS_6.7_x64
-  Revision: 20
-  Publisher: RightScale
-- Name: CentOS_6.7_x64_KVM
-  Revision: 27
-  Publisher: RightScale
-- Name: CentOS_7.1_x64
-  Revision: 28
-  Publisher: RightScale
-- Name: CentOS_7.2_x64_KVM
-  Revision: 26
-  Publisher: RightScale
+- Name: CentOS_6.x_x64
+- Name: CentOS_6.x_x64_KVM
+- Name: CentOS_7.x_x64
+- Name: CentOS_7.x_x64_KVM
 - Name: CoreOS_stable_x64
-  Revision: 34
-  Publisher: RightScale
 - Name: CoreOS_stable_x64_KVM
-  Revision: 17
-  Publisher: RightScale
 - Name: RHEL_6.x_x64_KVM
-  Revision: 5
-  Publisher: RightScale
 - Name: RHEL_7.x_x64_KVM
-  Revision: 6
-  Publisher: RightScale
-- Name: RHEL_6.8_x64
-  Revision: 8
-  Publisher: RightScale
-- Name: RHEL_7.2_x64
-  Revision: 6
-  Publisher: RightScale
+- Name: RHEL_6.x_x64
+- Name: RHEL_7.x_x64
 Alerts:
 - Name: rs instance terminated
   Description: Raise an alert if the instance has been terminated abnormally, i.e.

--- a/rlw/base.yml
+++ b/rlw/base.yml
@@ -65,20 +65,10 @@ RightScripts:
   - shutdown-reason.ps1
 MultiCloudImages:
 - Name: Windows_Server_Standard_2012R2_x64
-  Revision: 16
-  Publisher: RightScale
 - Name: Windows_Server_Datacenter_2012R2_x64
-  Revision: 19
-  Publisher: RightScale
 - Name: Windows_Server_Standard_2012_x64
-  Revision: 17
-  Publisher: RightScale
 - Name: Windows_Server_Datacenter_2012_x64
-  Revision: 11
-  Publisher: RightScale
 - Name: Windows_Server_Datacenter_2008R2_x64
-  Revision: 31
-  Publisher: RightScale
 Alerts:
 - Name: rs instance terminated
   Description: The instance has been terminated anormally, i.e., not through the RightScale


### PR DESCRIPTION
Just refer to head versions, simplify our lives. Also changed consistently to 6.x and 7.x for CentOS/RHEL. @NickBediRs 