### PR TITLE
Fixed attachment reference

### DIFF
--- a/rlw-examples/mssql-monitoring.ps1
+++ b/rlw-examples/mssql-monitoring.ps1
@@ -3,7 +3,7 @@
 # Description: Installs Microsoft SQL Server specific monitoring.
 # Inputs: {}
 # Attachments:
-#   - iis-monitor.ps1
+#   - mssql-monitor.ps1
 # ...
 #
 


### PR DESCRIPTION
Looks like attachment on this RightScale example is pointing to the wrong filename