### PR TITLE
Adding libyajl2 to monitoring install as its a requirement for collectd on Ubuntu 18.04

### DIFF
--- a/rll/enable-monitoring.sh
+++ b/rll/enable-monitoring.sh
@@ -277,7 +277,7 @@ else
   if [[ -d /etc/apt ]]; then
     # Resync the package index with sources
     retry_command sudo apt-get update -y
-    retry_command sudo apt-get install -y curl collectd-core
+    retry_command sudo apt-get install -y curl libyajl2 collectd-core
   elif [[ -d /etc/yum.repos.d ]]; then
     # Workaround for broken collectd
     if yum info collectd | grep -E '5.6.1|5.6.0'; then


### PR DESCRIPTION
When using base server template on Ubuntu 18.04 collectd-core does not install libyajl2 and so collectd fails to start. 