### PR TITLE
Ubuntu 20.04 requires libcurl3-gnutls

### DIFF
--- a/rll/enable-monitoring.sh
+++ b/rll/enable-monitoring.sh
@@ -277,7 +277,7 @@ else
   if [[ -d /etc/apt ]]; then
     # Resync the package index with sources
     retry_command sudo apt-get update -y
-    retry_command sudo apt-get install -y curl libyajl2 collectd-core
+    retry_command sudo apt-get install -y curl libcurl3-gnutls libyajl2 collectd-core
   elif [[ -d /etc/yum.repos.d ]]; then
     # Workaround for broken collectd
     if yum info collectd | grep -E '5.6.1|5.6.0'; then


### PR DESCRIPTION
Ensures the [libcurl dependency](https://collectd.org/wiki/index.php/Plugin:Write_HTTP#Dependencies) is in place for the `write_http` collectd plugin.

Libcurl had been in place via `git`'s dependencies on most of the hosts I work on, but on an Ubuntu 20.04 LTS host without git installed, `enable-monitoring.sh` would fail. 